### PR TITLE
String formatting updated

### DIFF
--- a/CVE-2021-22005_PoC.py
+++ b/CVE-2021-22005_PoC.py
@@ -79,7 +79,7 @@ manifestData = """<manifest recommendedPageSize="500">
          </queries>
       </schedule>
    </requestSchedules>
-</manifest>""" % (shell_name, pwd, pwd)
+</manifest>""".format(shell_name, pwd, pwd)
 
 target = sys.argv[1]
 print("Target: "+ target)


### PR DESCRIPTION
The manifestData string cannot be formatted using the % operator and gives a TypeError. This change should work things out.